### PR TITLE
Fix override of interfaces on updating entities in hkgraph

### DIFF
--- a/hkgraph.js
+++ b/hkgraph.js
@@ -73,10 +73,8 @@ HKGraph.prototype.setEntity = function(entity)
 
     if(entity.type === Types.NODE || entity.type === Types.REFERENCE || entity.type === Types.CONTEXT)
     {
-        if(entity.interfaces)
-        {
-            oldEntity.interfaces = entity.interfaces;
-        }
+        
+        oldEntity.interfaces = entity.interfaces;
     }
 
 	// Update parent


### PR DESCRIPTION
This commit fix a bug when updating entities that do not have interfaces (or anchors).