### PR TITLE
Adding a function to access the datasource info

### DIFF
--- a/datasource/hkdatasource.js
+++ b/datasource/hkdatasource.js
@@ -89,7 +89,7 @@ function convertEntities(raw)
 
 HKDatasource.prototype.getInfo = function (callback = () => {})
 {
-	request.get(`${this.url}/info`, this.options, (err, res) =>
+	request.get(`${this.url}info`, this.options, (err, res) =>
 	{
 		if(!err)
 		{

--- a/datasource/hkdatasource.js
+++ b/datasource/hkdatasource.js
@@ -78,6 +78,46 @@ function convertEntities(raw)
 }
 
 /**
+ * @callback OperationCallback
+ * @param err An error object that indicate if the operation was succesful or not
+ */
+/**
+ * Get information about the current IDB
+ *
+ * @param {OperationCallback} callback Response callback
+ */
+
+HKDatasource.prototype.getInfo = function (callback = () => {})
+{
+	request.get(`${this.url}/info`, this.options, (err, res) =>
+	{
+		if(!err)
+		{
+			if(requestCompletedWithSuccess (res.statusCode))
+			{
+				try
+				{
+					let data = JSON.parse(res.body);
+					callback(null, data);
+				}
+				catch(exp)
+				{
+					callback(exp);
+				}
+			}
+			else
+			{
+				callback(`Server responded with ${res.statusCode}. ${res.body}`);
+			}
+		}
+		else
+		{
+			callback(err);
+		}
+	});
+}
+
+/**
  * Callback function for `addEntities`
  *
  * @callback ListRepositoriesCallback

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hklib",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "main": "index.js",
   "author": "IBM Research",
   "contributors": [


### PR DESCRIPTION
Adding a function to access the datasource `info`.  This function returns information related to the database used as a backend for the datasource. Examples of information are the query language supported (e.g. sparql), database name (e.g. apache jena), database version (e.g. apache jena fuseki 3.16.0)  and so on.