### PR TITLE
Automatically reconnect and buffer messages when rabbitmq broker connection gets lost

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hklib",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "main": "index.js",
   "author": "IBM Research",
   "contributors": [
@@ -35,6 +35,7 @@
   ],
   "dependencies": {
     "amqplib": "^0.8.0",
+    "amqp-connection-manager": "~3.2.2",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "nearley": "^2.20.1",


### PR DESCRIPTION
Automatically reconnect and buffer notification messages when rabbitmq broker connection gets lost using [amqp-connection-manager](https://www.npmjs.com/package/amqp-connection-manager).
