### PR TITLE
Virtual context

### DIFF
--- a/deserialize.js
+++ b/deserialize.js
@@ -24,7 +24,7 @@ function _deserialize(input)
     case Node.type:
       return new Node(input);
     case Context.type:
-      if (input.properties !== undefined && input.properties.src !== undefined) return new VirtualContext(input);
+      if (input.properties !== undefined && input.properties.virtualSrc !== undefined) return new VirtualContext(input);
       return new Context(input);
     case Link.type:
       return new Link(input);

--- a/deserialize.js
+++ b/deserialize.js
@@ -24,7 +24,7 @@ function _deserialize(input)
     case Node.type:
       return new Node(input);
     case Context.type:
-      if (input.properties !== undefined && input.properties.endpoint !== undefined) return new VirtualContext(input);
+      if (input.properties !== undefined && input.properties.src !== undefined) return new VirtualContext(input);
       return new Context(input);
     case Link.type:
       return new Link(input);

--- a/deserialize.js
+++ b/deserialize.js
@@ -24,7 +24,7 @@ function _deserialize(input)
     case Node.type:
       return new Node(input);
     case Context.type:
-      if (input.properties !== undefined && input.properties.virtualSrc !== undefined) return new VirtualContext(input);
+      if (input.properties !== undefined && input.properties.virtualsrc !== undefined) return new VirtualContext(input);
       return new Context(input);
     case Link.type:
       return new Link(input);

--- a/deserialize.js
+++ b/deserialize.js
@@ -5,38 +5,38 @@
 
 "use strict";
 
-const Node            = require("./node");
-const Context         = require("./context");
-const Connector       = require("./connector");
-const Reference       = require("./reference");
-const Link            = require("./link");
-const Trail           = require("./trail");
+const Node = require("./node");
+const Context = require("./context");
+const Connector = require("./connector");
+const Reference = require("./reference");
+const Link = require("./link");
+const Trail = require("./trail");
 const VirtualContext = require("./virtualcontext");
 
 function _deserialize(input)
 {
-    if( !input || !input.type)
-    {
-        return null;
-    }
-    switch(input.type)
-    {
-        case Node.type:
-            return new Node(input);
-        case Context.type:
-			if(input.endpoint) return new VirtualContext(input);
-            return new Context(input);
-        case Link.type:
-            return new Link(input);
-        case Reference.type:
-            return new Reference(input);
-        case Connector.type:
-            return new Connector(input);
-        case Trail.type:
-            return new Trail(input);
-        default:
-            return null;
-    }
+  if (!input || !input.type)
+  {
+    return null;
+  }
+  switch (input.type)
+  {
+    case Node.type:
+      return new Node(input);
+    case Context.type:
+      if (input.properties !== undefined && input.properties.endpoint !== undefined) return new VirtualContext(input);
+      return new Context(input);
+    case Link.type:
+      return new Link(input);
+    case Reference.type:
+      return new Reference(input);
+    case Connector.type:
+      return new Connector(input);
+    case Trail.type:
+      return new Trail(input);
+    default:
+      return null;
+  }
 }
 
 /**
@@ -47,30 +47,30 @@ function _deserialize(input)
  */
 function deserialize(serialized)
 {
-    if(typeof serialized === "string")
-    {
-        serialized = JSON.parse(serialized);
-    }
+  if (typeof serialized === "string")
+  {
+    serialized = JSON.parse(serialized);
+  }
 
-    if(Array.isArray(serialized))
-    {
-        let out = [];
+  if (Array.isArray(serialized))
+  {
+    let out = [];
 
-        for(let i = 0; i < serialized.length; i++)
-        {
-            let e = _deserialize(serialized[i]);
-            if(e)
-            {
-                out.push(e);
-            }
-        }
-        return out;
-    }
-    else if(typeof serialized === "object")
+    for (let i = 0; i < serialized.length; i++)
     {
-        return _deserialize(serialized);
+      let e = _deserialize(serialized[i]);
+      if (e)
+      {
+        out.push(e);
+      }
     }
-    return null;
+    return out;
+  }
+  else if (typeof serialized === "object")
+  {
+    return _deserialize(serialized);
+  }
+  return null;
 }
 
 module.exports = deserialize;

--- a/hkgraph.js
+++ b/hkgraph.js
@@ -80,15 +80,6 @@ HKGraph.prototype.setEntity = function (entity)
 
 	}
 
-  // if (entity.type === Types.CONTEXT)
-  // {
-  //   if(entity.properties !== undefined &&  entity.properties.endpoint !== undefined && entity.properties.endpoint !== "")
-  //   {
-  //     oldEntity.endpoint = entity.endpoint;
-  //   }
-  //   oldEntity.interfaces = entity.interfaces;
-  // }
-
 	// Update parent
 
 	// Clean old entity

--- a/hkgraph.js
+++ b/hkgraph.js
@@ -73,21 +73,21 @@ HKGraph.prototype.setEntity = function (entity)
 		oldEntity.className = entity.className;
 	}
 
-	if (entity.type === Types.NODE || entity.type === Types.REFERENCE)
+	if (entity.type === Types.NODE || entity.type === Types.REFERENCE || entity.type === Types.CONTEXT)
 	{
 
 		oldEntity.interfaces = entity.interfaces;
 
 	}
 
-  if (entity.type === Types.CONTEXT)
-  {
-    if(entity.endpoint !== undefined && entity.endpoint !== "")
-    {
-      oldEntity.endpoint = entity.endpoint;
-    }
-    oldEntity.interfaces = entity.interfaces;
-  }
+  // if (entity.type === Types.CONTEXT)
+  // {
+  //   if(entity.properties !== undefined &&  entity.properties.endpoint !== undefined && entity.properties.endpoint !== "")
+  //   {
+  //     oldEntity.endpoint = entity.endpoint;
+  //   }
+  //   oldEntity.interfaces = entity.interfaces;
+  // }
 
 	// Update parent
 

--- a/hkgraph.js
+++ b/hkgraph.js
@@ -73,11 +73,21 @@ HKGraph.prototype.setEntity = function (entity)
 		oldEntity.className = entity.className;
 	}
 
-	if (entity.type === Types.NODE || entity.type === Types.REFERENCE || entity.type === Types.CONTEXT)
+	if (entity.type === Types.NODE || entity.type === Types.REFERENCE)
 	{
 
 		oldEntity.interfaces = entity.interfaces;
+
 	}
+
+  if (entity.type === Types.CONTEXT)
+  {
+    if(entity.endpoint !== undefined && entity.endpoint !== "")
+    {
+      oldEntity.endpoint = entity.endpoint;
+    }
+    oldEntity.interfaces = entity.interfaces;
+  }
 
 	// Update parent
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hklib",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "main": "index.js",
   "author": "IBM Research",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hklib",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "main": "index.js",
   "author": "IBM Research",
   "contributors": [

--- a/test/unit/entity.js
+++ b/test/unit/entity.js
@@ -45,7 +45,6 @@ describe("Contexts unit tests:", () => {
 
 		console.log(vContext);
 		HKDatasource.saveEntities([vContext], (err, data)=> {
-			console.log(data);
 			if (err) throw err;
 			done();
 

--- a/virtualcontext.js
+++ b/virtualcontext.js
@@ -32,7 +32,7 @@ function VirtualContext(id, src=null, parent=null)
 	{
 		this.id = id || null;
 		this.parent = parent || null;
-		this.properties = {"readonly": true, "src": src};
+		this.properties = {"readonly": true, "virtualSrc": src};
 	}
 
 	this.type = Types.CONTEXT;
@@ -49,7 +49,7 @@ function isValid(entity)
 	{
 		if (entity.hasOwnProperty('type') && entity.type === Types.CONTEXT &&
 			entity.hasOwnProperty('id') && entity.hasOwnProperty('parent') &&
-			entity.properties !== undefined && entity.properties.hasOwnProperty('src'))
+			entity.properties !== undefined && entity.properties.hasOwnProperty('virtualSrc'))
 		{
 			isValid = true;
 		}

--- a/virtualcontext.js
+++ b/virtualcontext.js
@@ -15,7 +15,6 @@ function VirtualContext(id, endpoint=null, parent=null)
 		let vContext = arguments[0];
 		this.id = vContext.id || null;
 		this.parent = vContext.parent || null;
-		this.endpoint = vContext.endpoint || null;
 		if (vContext.properties)
 		{
 			this.properties = vContext.properties;
@@ -32,7 +31,6 @@ function VirtualContext(id, endpoint=null, parent=null)
 	else
 	{
 		this.id = id || null;
-		this.endpoint = endpoint || null;
 		this.parent = parent || null;
 		this.properties = {"readonly": true, "endpoint": endpoint};
 	}
@@ -51,7 +49,7 @@ function isValid(entity)
 	{
 		if (entity.hasOwnProperty('type') && entity.type === Types.CONTEXT &&
 			entity.hasOwnProperty('id') && entity.hasOwnProperty('parent') &&
-			entity.hasOwnProperty('endpoint'))
+			entity.properties !== undefined && entity.properties.hasOwnProperty('endpoint'))
 		{
 			isValid = true;
 		}

--- a/virtualcontext.js
+++ b/virtualcontext.js
@@ -8,7 +8,7 @@
 const Types = require("./types");
 const Context = require("./context");
 
-function VirtualContext(id, src=null, parent=null)
+function VirtualContext(id, virtualSrc=null, parent=null)
 {
 	if (arguments[0] && typeof arguments[0] === "object")
 	{
@@ -32,10 +32,9 @@ function VirtualContext(id, src=null, parent=null)
 	{
 		this.id = id || null;
 		this.parent = parent || null;
-		this.properties = {"readonly": true, "virtualSrc": src};
+		this.properties = {"readonly": true, "virtualsrc": virtualSrc};
 	}
 
-	this.type = Types.CONTEXT;
 }
 
 VirtualContext.prototype = Object.create(Context.prototype);
@@ -49,7 +48,7 @@ function isValid(entity)
 	{
 		if (entity.hasOwnProperty('type') && entity.type === Types.CONTEXT &&
 			entity.hasOwnProperty('id') && entity.hasOwnProperty('parent') &&
-			entity.properties !== undefined && entity.properties.hasOwnProperty('virtualSrc'))
+			entity.properties !== undefined && entity.properties.hasOwnProperty('virtualsrc'))
 		{
 			isValid = true;
 		}

--- a/virtualcontext.js
+++ b/virtualcontext.js
@@ -35,6 +35,8 @@ function VirtualContext(id, virtualSrc=null, parent=null)
 		this.properties = {"readonly": true, "virtualsrc": virtualSrc};
 	}
 
+  this.type = Types.CONTEXT;
+
 }
 
 VirtualContext.prototype = Object.create(Context.prototype);

--- a/virtualcontext.js
+++ b/virtualcontext.js
@@ -8,7 +8,7 @@
 const Types = require("./types");
 const Context = require("./context");
 
-function VirtualContext(id, endpoint=null, parent=null)
+function VirtualContext(id, src=null, parent=null)
 {
 	if (arguments[0] && typeof arguments[0] === "object")
 	{
@@ -32,7 +32,7 @@ function VirtualContext(id, endpoint=null, parent=null)
 	{
 		this.id = id || null;
 		this.parent = parent || null;
-		this.properties = {"readonly": true, "endpoint": endpoint};
+		this.properties = {"readonly": true, "src": src};
 	}
 
 	this.type = Types.CONTEXT;
@@ -49,7 +49,7 @@ function isValid(entity)
 	{
 		if (entity.hasOwnProperty('type') && entity.type === Types.CONTEXT &&
 			entity.hasOwnProperty('id') && entity.hasOwnProperty('parent') &&
-			entity.properties !== undefined && entity.properties.hasOwnProperty('endpoint'))
+			entity.properties !== undefined && entity.properties.hasOwnProperty('src'))
 		{
 			isValid = true;
 		}

--- a/virtualcontext.js
+++ b/virtualcontext.js
@@ -34,7 +34,7 @@ function VirtualContext(id, endpoint=null, parent=null)
 		this.id = id || null;
 		this.endpoint = endpoint || null;
 		this.parent = parent || null;
-		this.properties = {"readonly": true};
+		this.properties = {"readonly": true, "endpoint": endpoint};
 	}
 
 	this.type = Types.CONTEXT;


### PR DESCRIPTION
This new version implements the idea of virtual context. Now, it is an entity that inherits the original attributes of the context class but has extra properties. The main property is the `virtualSrc` which should contain an endpoint of a query service that represents a remote base. We also include the readonly property to indicate that an instance of this object only allows reading access.