### PR TITLE
Adding function to retrieve context children. 

### DIFF
--- a/datasource/hkdatasource.js
+++ b/datasource/hkdatasource.js
@@ -504,6 +504,56 @@ HKDatasource.prototype.fetchContext = function(context, callback = () => {})
 }
 
 /**
+ * Fetch entities from a context
+ *
+ * @param {string} context The context id to retrieve their nested entities. May be null to get the `body` context.
+ * @param {object} payload A dictionary containing options when returning the entities from the context.
+ * @param {GetEntitiesCallback} callback Callback with the entities
+ */
+
+ HKDatasource.prototype.getContextChildrenLazy = function(context, payload, callback = () => {})
+ {
+   let url = `${this.url}repository/${this.graphName}/context/${context}/lazy`;
+   
+   Object.assign(payload, this.options);
+   const options = {
+    method: 'POST',
+    url: url,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: payload,
+    json: true
+  };
+   
+   request(options, (err, res) =>
+   { 
+     if(!err)
+     {
+       if(requestCompletedWithSuccess (res.statusCode))
+       {
+         try
+         {
+           callback(null, res.body);
+         }
+         catch(exp)
+         {
+           callback(exp);
+         }
+       }
+       else
+       {
+         callback(`Server responded with ${res.statusCode}. ${res.body}`);
+       }
+     }
+     else
+     {
+       callback(err);
+     }
+   });
+ }
+
+/**
  * Filter entities using CSS pattern `(TODO: document it better)`
  *
  * Examples:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hklib",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "main": "index.js",
   "author": "IBM Research",
   "contributors": [

--- a/test/unit/entity.js
+++ b/test/unit/entity.js
@@ -15,7 +15,7 @@ const HKDatasource = util.preamble();
 
 describe("Contexts unit tests:", () => {
 
-	before(done => {
+	beforeEach(done => {
 		HKDatasource.createRepository((err,  data)=>
 		{
 			if (err) throw err;
@@ -24,7 +24,7 @@ describe("Contexts unit tests:", () => {
 		});
 	}); 
 
-	after(done => {
+	afterEach(done => {
 		HKDatasource.dropRepository((err,  data)=> {
 			if (err) throw err;
 			done();
@@ -44,7 +44,6 @@ describe("Contexts unit tests:", () => {
 	it("Add Virtual Context", done => {
 		const vContext = new VContext("VContext", "http://dbpedia.org/sparql");
 
-		console.log(vContext);
 		HKDatasource.saveEntities([vContext], (err, data)=> {
 			if (err) throw err;
 			done();
@@ -69,7 +68,7 @@ describe("Contexts unit tests:", () => {
       HKDatasource.getContextChildrenLazy(context.id, payload, (err, data)=>{
         if (err) throw err;
         
-        expect([context.id, node.id].sort()).to.be.deep.equal(data.sort());
+        expect([context.id, node.id].sort()).to.be.deep.equal(Object.keys(data).sort());
         done();
       })
 			
@@ -93,7 +92,7 @@ describe("Contexts unit tests:", () => {
       HKDatasource.getContextChildrenLazy(context.id, payload, (err, data)=>{
         if (err) throw err;
         
-        expect([node.id]).to.be.deep.equal(data);
+        expect([node.id]).to.be.deep.equal(Object.keys(data));
         done();
       })
       
@@ -117,7 +116,32 @@ describe("Contexts unit tests:", () => {
       HKDatasource.getContextChildrenLazy(context.id, payload, (err, data)=>{
         if (err) throw err;
         
-        expect([node.id]).to.be.deep.equal(data);
+        expect([node.id]).to.be.deep.equal(Object.keys(data));
+        done();
+      })
+      
+    });
+  });
+
+  it("Test fetch context nodes children", done => {
+    const context = new Context("Parent");
+    const vContext = new VContext("VContext", "http://dbpedia.org/sparql", "Parent")
+
+    HKDatasource.saveEntities([context, vContext], (err, data)=> {
+      if (err) throw err;
+
+      const payload = {
+        "hkTypes": ["context"],
+        "nested": false,
+        "includeContextOnResults": false,
+        "fieldsToInclude": { "fields": ["id", "parent"], "properties": ["virtualsrc"]}
+      }
+      
+      HKDatasource.getContextChildrenLazy(context.id, payload, (err, data)=>{
+        if (err) throw err;
+        expect(vContext.id).to.be.deep.equal(Object.values(data)[0].id);
+        expect(vContext.parent).to.be.deep.equal(Object.values(data)[0].parent);
+        expect(vContext.properties["virtualsrc"]).to.be.equal(Object.values(data)[0].properties["virtualsrc"]);
         done();
       })
       

--- a/test/unit/entity.js
+++ b/test/unit/entity.js
@@ -6,6 +6,7 @@ const expect = require("chai").expect;
 const util = require("../common");
 
 const Context = require("../../context");
+const Node = require("../../node");
 const VContext = require("../../virtualcontext");
 const HKEntity = require("../../hkentity");
 
@@ -40,7 +41,7 @@ describe("Contexts unit tests:", () => {
 	});
 
 	
-	it("Add Virtual Context'", done => {
+	it("Add Virtual Context", done => {
 		const vContext = new VContext("VContext", "http://dbpedia.org/sparql");
 
 		console.log(vContext);
@@ -51,4 +52,75 @@ describe("Contexts unit tests:", () => {
 		});
 			
 	});
+
+  it("Test fetch context children including context", done => {
+		const context = new Context("Parent");
+    const node = new Node("Son", context.id);
+
+		HKDatasource.saveEntities([context, node], (err, data)=> {
+			if (err) throw err;
+
+      const payload = {
+        "specificTypes": [],
+        "nested": false,
+        "includeContextOnResults": true
+      }
+      
+      HKDatasource.getContextChildrenLazy(context.id, payload, (err, data)=>{
+        if (err) throw err;
+        
+        expect([context.id, node.id].sort()).to.be.deep.equal(data.sort());
+        done();
+      })
+			
+		});
+			
+	});
+
+  it("Test fetch context children not including context", done => {
+    const context = new Context("Parent");
+    const node = new Node("Son", context.id);
+
+    HKDatasource.saveEntities([context, node], (err, data)=> {
+      if (err) throw err;
+
+      const payload = {
+        "specificTypes": [],
+        "nested": false,
+        "includeContextOnResults": false
+      }
+      
+      HKDatasource.getContextChildrenLazy(context.id, payload, (err, data)=>{
+        if (err) throw err;
+        
+        expect([node.id]).to.be.deep.equal(data);
+        done();
+      })
+      
+    });
+  });
+
+  it("Test fetch context nodes children", done => {
+    const context = new Context("Parent");
+    const node = new Node("Son", context.id);
+    const nested = new Context("Nested", context.id);
+
+    HKDatasource.saveEntities([context, node, nested], (err, data)=> {
+      if (err) throw err;
+
+      const payload = {
+        "specificTypes": ["node"],
+        "nested": false,
+        "includeContextOnResults": false
+      }
+      
+      HKDatasource.getContextChildrenLazy(context.id, payload, (err, data)=>{
+        if (err) throw err;
+        
+        expect([node.id]).to.be.deep.equal(data);
+        done();
+      })
+      
+    });
+  });
 })

--- a/test/unit/entity.js
+++ b/test/unit/entity.js
@@ -61,7 +61,7 @@ describe("Contexts unit tests:", () => {
 			if (err) throw err;
 
       const payload = {
-        "specificTypes": [],
+        "hkTypes": [],
         "nested": false,
         "includeContextOnResults": true
       }
@@ -85,7 +85,7 @@ describe("Contexts unit tests:", () => {
       if (err) throw err;
 
       const payload = {
-        "specificTypes": [],
+        "hkTypes": [],
         "nested": false,
         "includeContextOnResults": false
       }
@@ -109,7 +109,7 @@ describe("Contexts unit tests:", () => {
       if (err) throw err;
 
       const payload = {
-        "specificTypes": ["node"],
+        "hkTypes": ["node"],
         "nested": false,
         "includeContextOnResults": false
       }


### PR DESCRIPTION
This function considers as a parameter a payload containing settings for retrieving the children of a context .
For instance: 
```
{
  "hkTypes": ["node"],
  "nested": false,
  "includeContextOnResults": false,
  "fieldsToInclude": { "fields": ["id", "parent", "type"], "properties": ["virtualsrc"]}
}
```
where `hkTypes` filters children of specifics hyperknowledge types; `nested` indicates if it should navigated in the inner contexts or not; `includeContextOnResults` indicates whether it should also return the context itself or not; and `fieldsToInclude` lists which entity fields and properties should be returned. By default only the identifier is returned (lazy mode). 
