### PR TITLE
Replacing the getContextChildrenLazy function to getContextChildren

### DIFF
--- a/datasource/hkdatasource.js
+++ b/datasource/hkdatasource.js
@@ -502,8 +502,7 @@ HKDatasource.prototype.fetchContext = function(context, callback = () => {})
 		}
 	});
 }
-
-/**
+ /**
  * Fetch entities from a context
  *
  * @param {string} context The context id to retrieve their nested entities. May be null to get the `body` context.
@@ -511,12 +510,12 @@ HKDatasource.prototype.fetchContext = function(context, callback = () => {})
  * @param {GetEntitiesCallback} callback Callback with the entities
  */
 
- HKDatasource.prototype.getContextChildrenLazy = function(context, payload, callback = () => {})
- {
-   let url = `${this.url}repository/${this.graphName}/context/${context}/lazy`;
-   
-   Object.assign(payload, this.options);
-   const options = {
+HKDatasource.prototype.getContextChildren = function(context, payload, callback = () => {})
+{
+  let url = `${this.url}repository/${this.graphName}/context/${context}`;
+  
+  Object.assign(payload, this.options);
+  const options = {
     method: 'POST',
     url: url,
     headers: {
@@ -525,33 +524,33 @@ HKDatasource.prototype.fetchContext = function(context, callback = () => {})
     body: payload,
     json: true
   };
-   
-   request(options, (err, res) =>
-   { 
-     if(!err)
-     {
-       if(requestCompletedWithSuccess (res.statusCode))
-       {
-         try
-         {
-           callback(null, res.body);
-         }
-         catch(exp)
-         {
-           callback(exp);
-         }
-       }
-       else
-       {
-         callback(`Server responded with ${res.statusCode}. ${res.body}`);
-       }
-     }
-     else
-     {
-       callback(err);
-     }
-   });
- }
+  
+  request(options, (err, res) =>
+  { 
+    if(!err)
+    {
+      if(requestCompletedWithSuccess (res.statusCode))
+      {
+        try
+        {
+          callback(null, res.body);
+        }
+        catch(exp)
+        {
+          callback(exp);
+        }
+      }
+      else
+      {
+        callback(`Server responded with ${res.statusCode}. ${res.body}`);
+      }
+    }
+    else
+    {
+      callback(err);
+    }
+  });
+}
 
 /**
  * Filter entities using CSS pattern `(TODO: document it better)`

--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ exports.BIND_TYPE = Types.BIND;
 exports.INTERFACE = Types.INTERFACE;
 exports.TRAIL_TYPE = Types.TRAIL;
 
+exports.VIRTUAL_SOURCE_PROPERTY = "virtualsrc";
+
 const RolesTypes = require("./roletypes");
 
 exports.RolesTypes = RolesTypes;

--- a/test/unit/entity.js
+++ b/test/unit/entity.js
@@ -15,7 +15,7 @@ const HKDatasource = util.preamble();
 
 describe("Contexts unit tests:", () => {
 
-	before(done => {
+	beforeEach(done => {
 		HKDatasource.createRepository((err,  data)=>
 		{
 			if (err) throw err;
@@ -24,7 +24,7 @@ describe("Contexts unit tests:", () => {
 		});
 	}); 
 
-	after(done => {
+	afterEach(done => {
 		HKDatasource.dropRepository((err,  data)=> {
 			if (err) throw err;
 			done();
@@ -44,7 +44,6 @@ describe("Contexts unit tests:", () => {
 	it("Add Virtual Context", done => {
 		const vContext = new VContext("VContext", "http://dbpedia.org/sparql");
 
-		console.log(vContext);
 		HKDatasource.saveEntities([vContext], (err, data)=> {
 			if (err) throw err;
 			done();
@@ -69,7 +68,7 @@ describe("Contexts unit tests:", () => {
       HKDatasource.getContextChildrenLazy(context.id, payload, (err, data)=>{
         if (err) throw err;
         
-        expect([context.id, node.id].sort()).to.be.deep.equal(data.sort());
+        expect([context.id, node.id].sort()).to.be.deep.equal(Object.keys(data).sort());
         done();
       })
 			
@@ -93,7 +92,7 @@ describe("Contexts unit tests:", () => {
       HKDatasource.getContextChildrenLazy(context.id, payload, (err, data)=>{
         if (err) throw err;
         
-        expect([node.id]).to.be.deep.equal(data);
+        expect([node.id]).to.be.deep.equal(Object.keys(data));
         done();
       })
       
@@ -117,7 +116,32 @@ describe("Contexts unit tests:", () => {
       HKDatasource.getContextChildrenLazy(context.id, payload, (err, data)=>{
         if (err) throw err;
         
-        expect([node.id]).to.be.deep.equal(data);
+        expect([node.id]).to.be.deep.equal(Object.keys(data));
+        done();
+      })
+      
+    });
+  });
+
+  it("Test fetch context nodes children", done => {
+    const context = new Context("Parent");
+    const vContext = new VContext("VContext", "http://dbpedia.org/sparql", "Parent")
+
+    HKDatasource.saveEntities([context, vContext], (err, data)=> {
+      if (err) throw err;
+
+      const payload = {
+        "hkTypes": ["context"],
+        "nested": false,
+        "includeContextOnResults": false,
+        "fieldsToInclude": { "fields": ["id", "parent"], "properties": ["virtualsrc"]}
+      }
+      
+      HKDatasource.getContextChildrenLazy(context.id, payload, (err, data)=>{
+        if (err) throw err;
+        expect(vContext.id).to.be.deep.equal(Object.values(data)[0].id);
+        expect(vContext.parent).to.be.deep.equal(Object.values(data)[0].parent);
+        expect(vContext.properties["virtualsrc"]).to.be.equal(Object.values(data)[0].properties["virtualsrc"]);
         done();
       })
       


### PR DESCRIPTION
The lazy parameter must be sent via payload, for instance:

```
{
  "hkTypes": ["node", "context", "trail"],
  "nested": false,
  "includeContextOnResults": true,
  "lazy": true,
  "fieldsToInclude": {"fields":["id", "type", "parent"]}
}
```


This PR also includes the exportation of the virtual source property constant: `exports.VIRTUAL_SOURCE_PROPERTY = "virtualsrc";` in the index.js file.